### PR TITLE
Make the stale-timeout configurable per pool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Usage: pool_boy.py [OPTIONS] COMMAND [ARGS]...
 Options:
   --verbose                Turn on verbose logging
   --repo TEXT              URL of the Concourse lock pool repo  [required]
-  --pools TEXT             Comma-separated list of pools to inspect inside the
-                           repo  [required]
-  --stale-timeout INTEGER  Staleness timeout in minutes  [default: 60]
+  --pools TEXT             Comma-separated list of pool name and timeout pairs. The pair
+                           items must be separated by ":", for example:
+                           worker_pool:60,tester_pool:30. The timeout parameter defines
+                           the number of minutes after which the lock is considered
+                           stale.  [required]
   --help                   Show this message and exit.
 
 Commands:
@@ -66,8 +68,7 @@ jobs:
         params:
           POOL_REPO: MY_CONCOURSE_LOCKS_REPO
           POOL_REPO_SSH_PRIVATE_KEY: ((MY_GIT_SSH_PRIVATE_KEY))
-          POOLS: MYLIST,OF,POOLS,INSIDE,THE,LOCK,REPO
-          STALE_TIMEOUT: 60
+          POOLS: POOL_1:STALE_TIMEOUT_1,POOL_2:STALE_TIMEOUT_2
 ```
 
 ## Testing

--- a/pool_boy.py
+++ b/pool_boy.py
@@ -9,7 +9,6 @@ import logging
 import os
 import os.path
 import shutil
-import textwrap
 from datetime import datetime, timedelta, timezone
 
 import click

--- a/pool_boy.sh
+++ b/pool_boy.sh
@@ -22,4 +22,4 @@ chmod 400 /root/.ssh/id_rsa
 
 echo
 echo "Running the pool boy"
-pool_boy.py --repo "${POOL_REPO}" --pools "${POOLS}" --stale-timeout "${STALE_TIMEOUT}" clean
+pool_boy.py --repo "${POOL_REPO}" --pools "${POOLS}" clean


### PR DESCRIPTION
This PR makes the `stale-timeout` parameter configurable per pool. The command line interface is extended such that the old behavior is preserved.

```
# same timeout for all pools
./pool_boy.py --repo <repo> --pools=pool_1,pool_2 --stale-timeout 5 status

# different timeout for each pool
./pool_boy.py --repo <repo> --pools=pool_1,pool_2 --stale-timeout 5 --stale-timeout 60 status
```