### PR TITLE
Check with concourse to see if a lock is really stalled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2018-12-13
+
+### Added
+
+- The pool boy can check if a floating body is dead or alive before cleaning it from the pool.
+
+## [0.2.0] - 2018-12-03
+
+### Changed
+
+- Made the timeout configurable per pool.
+
 ## [0.1.0] - 2018-10-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Like a an efficient pool boy, keep the pools of the [Concourse pool-resource] clean from debris.
 
+For an even smarter pool boy, you can tell him to check if a floating body is still alive before
+cleaning it by using our improved [Pix4D pool-resource] and setting the parameters
+`CONCOURSE_BASE_URL`, `CONCOURSE_USERNAME` and `CONCOURSE_PASSWORD` (see below).
+
 Can be used from the command-line or from a Concourse pipeline.
 
 ## Status
@@ -66,14 +70,25 @@ jobs:
           run:
             path: /usr/local/bin/pool_boy.sh
         params:
+          CONCOURSE_BASE_URL: http://my-concourse.local
+          CONCOURSE_USERNAME: ((THE_CONCOURSE_USER))
+          CONCOURSE_PASSWORD: ((THE_USER_PASSWORD))
           POOL_REPO: MY_CONCOURSE_LOCKS_REPO
           POOL_REPO_SSH_PRIVATE_KEY: ((MY_GIT_SSH_PRIVATE_KEY))
           POOLS: POOL_1:STALE_TIMEOUT_1,POOL_2:STALE_TIMEOUT_2
 ```
 
+`CONCOURSE_BASE_URL` is optional. It should be identical to the `--concourse-url` value passed to
+`fly`. If present the `CONCOURSE_USERNAME` and `CONCOURSE_PASSWORD` are mandatory and they must be
+valid Concourse credential with the appropriate rights to see the status of the builds that uses
+the configured `POOL_REPO`.
+
 ## Caveats
 
-Note that if the following events happen in this timed sequence, a pipeline failure will happen:
+Note that if the `CONCOURSE_BASE_URL` is not specified, the pool boy won't be able to validate if
+the build that last claimed a lock is still alive or not and will then rely solely on the staleness
+timeout configured. This will typically result in a pipeline failure when the following sequence of
+events happen:
 
 1. A job acquires lock `lock-1`.
 2. Time passes by, the Pool Boy detects `lock-1` as stale and brings it back to the available pool.
@@ -147,3 +162,4 @@ Note: there is no built-in help for git subtree, on the other hand the very good
 
 
 [Concourse pool-resource]: https://github.com/concourse/pool-resource
+[Pix4D pool-resource]: https://github.com/Pix4D/pool-resource

--- a/pool_boy.py
+++ b/pool_boy.py
@@ -17,7 +17,7 @@ import dateutil.parser
 import requests
 from vendor.brigit.brigit import Git
 
-CONCOURSE_BASE_URL = os.environ['CONCOURSE_BASE_URL']
+CONCOURSE_BASE_URL = os.environ.get('CONCOURSE_BASE_URL')
 CLAIM_COMMIT_RE = re.compile(
     r'[0-9a-f]+\s+'
     r'(?P<team>.*)/(?P<pipeline>.*)/(?P<job>.*)\s+build\s+(?P<build>.*)\s+'
@@ -64,6 +64,12 @@ class BearerAuth(requests.auth.AuthBase):
 
 
 def get_concourse_auth():
+    """Exchange the username and password for a token
+
+    See: https://www.oauth.com/oauth2-servers/access-tokens/password-grant/
+    """
+    if CONCOURSE_BASE_URL is None:
+        return None
     url = CONCOURSE_BASE_URL + '/sky/token'
     username = os.environ['CONCOURSE_USERNAME']
     password = os.environ['CONCOURSE_PASSWORD']
@@ -82,6 +88,9 @@ def get_concourse_auth():
 
 
 def is_build_alive(auth, team, pipeline, job, build):
+    if not auth:
+        return None
+
     reply = requests.get(
         CONCOURSE_BASE_URL + f'/api/v1/teams/{team}/pipelines/{pipeline}/jobs/{job}/builds/{build}',
         auth=auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click >= 7.0
 python-dateutil >= 2.7.3
+requests >= 2.21.0


### PR DESCRIPTION
Jobs can take longer then the configured stale timeout, in which case the lock would be release while the protected resource is still in use. This can cause havoc if a new job gets scheduled.

This PR relies on https://github.com/Pix4D/pool-resource/pull/2 to get enough information from the commit log to check with concourse if the build is still alive or not. In the former case, the lock will not be cleared.

You can examine https://builder.ci.pix4d.com/teams/main/pipelines/smart-boy to see that it will only clear the stalled lock after the timeout occurred and the build finished.

I'm tempted to change a bit the implementation to allow releasing the lock if the build status could be found and indicates the build is over even when the stale timeout is not over. This way, the lock wouldn't be held for nothing. I would keep the timeout as a safety measure for the cases when some error occurs while checking with concourse if a build is finished or not.